### PR TITLE
add app sso selfsign ca cert for gateway service

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,29 @@ For a TLS setup:
 ytt -f tap/ops/auth-server-template.yaml -v dev_namespace=$DEV_NAMESPACE -v issuer_uri=https://authserver-1-${DEV_NAMESPACE}.example.com -v tls_secret_name=<namespace>/<secret> | kubectl apply -f -
 ```
 
+`Note:` in case your App SSO tls is a selfsigned certificate, you need extra steps at `gateway workload` creation where you need to bind App SSO CA cert to gateway service. 
+
+```
+
+ytt -f tap/ops/gateway-ca-extra-template.yaml -v dev_namespace=$DEV_NAMESPACE --data-value-file appsso_ca_pem=<generated appsso-ca.pem>
+```
+
+```
+# And Optional serviceClaims should added in gateway Workload yaml
+
+serviceClaims:
+  - name: appsso-ca
+    ref:
+      apiVersion: services.apps.tanzu.vmware.com/v1alpha1
+      kind: ResourceClaim
+      name: gateway-ca-extra-binding-compatible
+```
+
+
 Otherwise:
 ```
 ytt -f tap/ops/auth-server-template.yaml -v dev_namespace=$DEV_NAMESPACE -v issuer_uri=http://authserver-1-${DEV_NAMESPACE}.example.com | kubectl apply -f -
+
 ```
 
 #### Observability

--- a/tap/ops/gateway-ca-extra-template.yaml
+++ b/tap/ops/gateway-ca-extra-template.yaml
@@ -1,0 +1,23 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gateway-ca-extra-binding-compatible
+  namespace: #@ data.values.dev_namespace
+type: servicebinding.io/ca-certificates
+stringData:
+  type: ca-certificates
+  provider: vmware
+  appsso-ca.pem: #@ data.values.appsso_ca_pem
+---
+apiVersion: services.apps.tanzu.vmware.com/v1alpha1
+kind: ResourceClaim
+metadata:
+  name: gateway-ca-extra-binding-compatible
+  namespace: #@ data.values.dev_namespace
+spec:
+  ref:
+    apiVersion: v1
+    kind: Secret
+    name: gateway-ca-extra-binding-compatible


### PR DESCRIPTION
In case your App SSO tls is self-signed certificate, you need extra steps at gateway workload creation where you need to bind App SSO CA cert to gateway service.